### PR TITLE
Improve playlist embeds

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -843,6 +843,13 @@ span {
     font-size: 1.5rem
 }
 
+.playlist-title {
+    font-size: 2rem;
+    width: 100%;
+    text-align: center;
+    margin-bottom: 1rem;
+}
+
 @media (max-width:1200px) {
     .education-column {
         width: 100%

--- a/js/script.js
+++ b/js/script.js
@@ -658,3 +658,71 @@ createEducationAndExperience([
         ]
     }
 ]);
+
+const playlistsData = [
+    { id: '5QKgUqfecHSprREJj1PDMy', title: 'Playlist 1' },
+    { id: '22OKbIAGCgBtYcEb3oXANT', title: 'Playlist 2' },
+    { id: '1FuX68Y0hFsO9s9K9JqYiA', title: 'Playlist 3' },
+    { id: '1bX2bXn075ZDOzLrUpsmmA', title: 'Playlist 4' },
+    { id: '6Yze0ZPWxWrCoAbgVGHVoC', title: 'Playlist 5' },
+    { id: '7A4tyCrZyn7N4yDvRkufSX', title: 'Playlist 6' },
+    { id: '597U1RL2lRYlXFq9zEMPaX', title: 'Playlist 7' },
+    { id: '4zaXhaW0mp4v4Exliuo0WH', title: 'Playlist 8' },
+    { id: '1uYneC2hyNcbRWnCztabYK', title: 'Playlist 9' },
+    { id: '0gMXaY9jKjUBk3ya8RZ8Gy', title: 'Playlist 10' }
+];
+
+function createPlaylists(list) {
+    const container = document.getElementById('playlist-container');
+    if (!container) return;
+
+    list.forEach(pl => {
+        const title = document.createElement('h3');
+        title.classList.add('playlist-title');
+        title.textContent = pl.title;
+        container.appendChild(title);
+
+        const iframe = document.createElement('iframe');
+        iframe.classList.add('playlist-iframe');
+        iframe.style.borderRadius = '12px';
+        iframe.setAttribute('data-src', `https://open.spotify.com/embed/playlist/${pl.id}?utm_source=generator`);
+        iframe.height = '352';
+        iframe.setAttribute('frameBorder', '0');
+        iframe.setAttribute('allowfullscreen', '');
+        iframe.setAttribute('allow', 'autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture');
+        iframe.loading = 'lazy';
+        container.appendChild(iframe);
+    });
+}
+
+function setupPlaylistLazyLoad() {
+    const overlay = document.getElementById('loading-overlay');
+    const iframes = document.querySelectorAll('.playlist-iframe');
+    let overlayHidden = false;
+
+    const observer = new IntersectionObserver(entries => {
+        entries.forEach(entry => {
+            if (entry.isIntersecting) {
+                const iframe = entry.target;
+                iframe.src = iframe.dataset.src;
+                observer.unobserve(iframe);
+
+                if (!overlayHidden) {
+                    iframe.addEventListener('load', function () {
+                        overlay.style.display = 'none';
+                    }, { once: true });
+                    overlayHidden = true;
+                }
+            }
+        });
+    }, { rootMargin: '0px 0px 100px 0px' });
+
+    iframes.forEach(iframe => observer.observe(iframe));
+}
+
+document.addEventListener('DOMContentLoaded', function () {
+    if (document.getElementById('playlist-container')) {
+        createPlaylists(playlistsData);
+        setupPlaylistLazyLoad();
+    }
+});

--- a/pages/playlists.html
+++ b/pages/playlists.html
@@ -148,58 +148,7 @@
 
     <section class="project-page" id="project-page">
         <h2 class="heading" data-aos="fade-down">Le mie <span>playlist</span></h2>
-        <div class="playlist-column">
-            <iframe style="border-radius:12px"
-                src="https://open.spotify.com/embed/playlist/5QKgUqfecHSprREJj1PDMy?utm_source=generator" width="40%"
-                height="352" frameBorder="0" allowfullscreen=""
-                allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture"
-                loading="lazy"></iframe>
-            <iframe style="border-radius:12px"
-                src="https://open.spotify.com/embed/playlist/22OKbIAGCgBtYcEb3oXANT?utm_source=generator" width="100%"
-                height="352" frameBorder="0" allowfullscreen=""
-                allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture"
-                loading="lazy"></iframe>
-            <iframe style="border-radius:12px"
-                src="https://open.spotify.com/embed/playlist/1FuX68Y0hFsO9s9K9JqYiA?utm_source=generator" width="100%"
-                height="352" frameBorder="0" allowfullscreen=""
-                allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture"
-                loading="lazy"></iframe>
-            <iframe style="border-radius:12px"
-                src="https://open.spotify.com/embed/playlist/1bX2bXn075ZDOzLrUpsmmA?utm_source=generator" width="100%"
-                height="352" frameBorder="0" allowfullscreen=""
-                allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture"
-                loading="lazy"></iframe>
-            <iframe style="border-radius:12px"
-                src="https://open.spotify.com/embed/playlist/6Yze0ZPWxWrCoAbgVGHVoC?utm_source=generator" width="100%"
-                height="352" frameBorder="0" allowfullscreen=""
-                allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture"
-                loading="lazy"></iframe>
-            <iframe style="border-radius:12px"
-                src="https://open.spotify.com/embed/playlist/7A4tyCrZyn7N4yDvRkufSX?utm_source=generator" width="100%"
-                height="352" frameBorder="0" allowfullscreen=""
-                allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture"
-                loading="lazy"></iframe>
-            <iframe style="border-radius:12px"
-                src="https://open.spotify.com/embed/playlist/597U1RL2lRYlXFq9zEMPaX?utm_source=generator" width="100%"
-                height="352" frameBorder="0" allowfullscreen=""
-                allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture"
-                loading="lazy"></iframe>
-            <iframe style="border-radius:12px"
-                src="https://open.spotify.com/embed/playlist/4zaXhaW0mp4v4Exliuo0WH?utm_source=generator" width="100%"
-                height="352" frameBorder="0" allowfullscreen=""
-                allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture"
-                loading="lazy"></iframe>
-            <iframe style="border-radius:12px"
-                src="https://open.spotify.com/embed/playlist/1uYneC2hyNcbRWnCztabYK?utm_source=generator" width="100%"
-                height="352" frameBorder="0" allowfullscreen=""
-                allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture"
-                loading="lazy"></iframe>
-            <iframe style="border-radius:12px"
-                src="https://open.spotify.com/embed/playlist/0gMXaY9jKjUBk3ya8RZ8Gy?utm_source=generator" width="100%"
-                height="352" frameBorder="0" allowfullscreen=""
-                allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture"
-                loading="lazy"></iframe>
-        </div>
+        <div id="playlist-container" class="playlist-column"></div>
         <!-- footer design -->
         <footer class="footer">
 
@@ -219,22 +168,7 @@
         <script>
             AOS.init();
         </script>
-        <script>
-            document.addEventListener("DOMContentLoaded", function () {
-                const iframes = document.querySelectorAll("iframe");
-                let loadedCount = 0;
 
-                iframes.forEach((iframe) => {
-                    iframe.onload = function () {
-                        loadedCount++;
-                        if (loadedCount === iframes.length) {
-                            document.getElementById("loading-overlay").style.display = "none";
-                        }
-                    };
-                });
-            });
-
-        </script>
 
 </body>
 


### PR DESCRIPTION
## Summary
- dynamically create playlist iframes and titles via JavaScript
- load playlists lazily with IntersectionObserver
- rely on CSS for widths and add `.playlist-title` rule
- clean up leftover `workbench` file

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_685d32c3dd90832b842e500c6e65b0a8